### PR TITLE
docs: add clarification for diabetes prediction input features

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,13 @@ The core feature uses a machine learning model trained on the Pima Indians Diabe
 
 The model processes these inputs through a StandardScaler for normalization and returns a binary prediction (Diabetic / Not Diabetic).
 
+### Note on Prediction Inputs
+
+The diabetes prediction model is trained on the Pima Indians Diabetes Dataset.
+Due to limitations of the dataset, gender and individual height/weight values are not included as input features.
+BMI is used as a combined indicator of height and weight.
+
+
 ### 2. Data Exploration Dashboard
 
 Interactive visualization tools for understanding diabetes-related health patterns:


### PR DESCRIPTION
### Summary
This pull request adds a short clarification to the README under the Diabetes Risk Prediction section.

### What was changed
- Added a note explaining why gender and individual height/weight values are not included as input features.
- Clarified that BMI is used as a combined indicator of height and weight.
- No changes were made to the existing model or application logic.

### Why this change is needed
Although the project mentions that the model is trained on the Pima Indians Diabetes Dataset, many users may not be familiar with the dataset’s feature limitations. As shown in the screenshot below, the prediction form does not include gender, height, or weight inputs, which may confuse users. This clarification helps set correct expectations for non-technical users.

### Screenshot
<img width="1920" height="1020" alt="Preview README md - Diabetes-care-with-AI - Visual Studio Code 05-01-2026 15_52_17" src="https://github.com/user-attachments/assets/85512c40-3f6f-4833-b181-655a8fdcd613" />


### Impact
- Improves transparency of the prediction process
- Reduces user confusion
- Helps new contributors better understand dataset constraints

This PR closes issue #49 

