### PR TITLE
Fix UI breaking on mobile devices (responsive navbar & layout)

### DIFF
--- a/templates/home.html
+++ b/templates/home.html
@@ -58,7 +58,7 @@
 
 .navbar {
   background: linear-gradient(135deg, var(--primary-blue), var(--dark-blue));
-  padding: 0.8rem 2rem;
+  padding: 12px 24px;
   box-shadow: 0 4px 15px rgba(0, 0, 0, 0.1);
   position: sticky;
   top: 0;
@@ -183,7 +183,61 @@
   .nav-menu {
     display: none; /* In a real PR, you'd add a hamburger menu toggle here */
   }
+  
 }
+@media (max-width: 480px) {
+  .navbar {
+    padding: 14px 10px; 
+  }
+  
+  .nav-logo {
+    gap: 0px;
+  }
+  
+  .nav-utils {
+    gap: 6px; 
+  }
+  
+  .nav-menu {
+    display: none;
+  }
+  
+  .logo-text {
+    font-size: 20px; 
+  }
+  
+  .btn-primary {
+    font-size: 14px; 
+    padding: 4px 8px;
+  }
+  
+  .lang-selector {
+    padding: 2px;
+  }
+  
+  .lang-selector select {
+    font-size: 12px;
+  }
+}
+@media (max-width: 375px) {
+  .navbar {
+    padding: 8px 6px; 
+  }
+   .logo-text {
+    font-size: 16px; 
+  }
+    .btn-primary {
+    font-size: 12px; 
+    padding: 4px 6px;
+  }
+    .nav-utils {
+    gap: 4px; 
+  }
+   .lang-selector select {
+    font-size: 10px;
+  }
+}
+
   </style>
 </head>
 


### PR DESCRIPTION
## What was fixed
- Resolved navbar overflow and layout breaking on mobile devices
- Improved responsiveness for phones, tablets, and small screens
- Prevented horizontal scrolling issues

## Breakpoints tested
- 320px
- 375px
- 425px
- 640px
- 768px

## Screenshots 

## 320px
<img width="617" height="830" alt="Screenshot 2026-01-08 164931" src="https://github.com/user-attachments/assets/25681b32-0a12-42d4-a14b-17e1f1716c8f" />

## 375px
<img width="658" height="830" alt="Screenshot 2026-01-08 164939 - Copy" src="https://github.com/user-attachments/assets/130b6e1b-fe21-44e4-9af2-a047e7674377" />

## 425px
<img width="720" height="819" alt="Screenshot 2026-01-08 164947 - Copy" src="https://github.com/user-attachments/assets/7a73ff54-076e-417c-8595-bea702212c10" />

## 640px
<img width="993" height="807" alt="Screenshot 2026-01-08 165009 - Copy" src="https://github.com/user-attachments/assets/50d0071f-e005-4ec9-902b-f22a1a26e521" />

## 768px
<img width="1181" height="799" alt="Screenshot 2026-01-08 165017" src="https://github.com/user-attachments/assets/24635866-c3a5-449d-8bcc-cb30b2c10aca" />




Closes #102 