### PR TITLE
feat: Redesign Prediction Page with White/Blue Theme

### DIFF
--- a/app.py
+++ b/app.py
@@ -544,13 +544,16 @@ def generate():
         if not user_input:
             return jsonify({'reply': "Please say something!"})
 
-        # --- NEW CODE START ---
+        api_key = os.getenv("GEMINI_API_KEY")
+        if not api_key:
+            return jsonify({'reply': "Error: Gemini API Key not configured."})
+
+        client = genai.Client(api_key=api_key)
         response = client.models.generate_content(
-            model='gemini-2.0-flash', # Or 'gemini-1.5-flash'
+            model='gemini-2.0-flash',
             contents=user_input
         )
         reply_text = response.text
-        # --- NEW CODE END ---
         
         return jsonify({'reply': reply_text})
     except Exception as e:

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,16 +1,14 @@
 <!DOCTYPE html>
 <html lang="en" class="scroll-smooth">
-
 <head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>{{ _('Diabetes Prediction') }}</title>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>{{ _('Diabetes Prediction') }} | {{ _('Diabetes Care') }}</title>
   <link rel="icon" href="{{ url_for('static', filename='stethoscope.png') }}" type="image/png" />
   <script src="https://cdn.tailwindcss.com"></script>
   <script>tailwind.config = { darkMode: 'class' }</script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/html2pdf.js/0.10.1/html2pdf.bundle.min.js"></script>
   <script>
-    // Apply dark mode before page renders to prevent flash
     (function() {
       var savedTheme = localStorage.getItem('theme');
       var prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
@@ -20,202 +18,318 @@
     })();
   </script>
   <style>
-    body {
-      background-image:
-        radial-gradient(circle at 20% 20%, rgba(255, 255, 255, 0.05) 0%, transparent 40%),
-        radial-gradient(circle at 80% 80%, rgba(255, 255, 255, 0.05) 0%, transparent 40%);
-      background-repeat: repeat;
-      background-size: 200px 200px;
+    * { transition: background-color 0.3s ease, border-color 0.3s ease; }
+    .glass-card {
+      background: rgba(255, 255, 255, 0.95);
+      backdrop-filter: blur(10px);
+      border: 1px solid rgba(255, 255, 255, 0.2);
     }
-    .lang-dropdown { max-height: 0; overflow: hidden; transition: max-height 0.2s ease-out; }
-    .lang-dropdown.show { max-height: 300px; }
+    .dark .glass-card {
+      background: rgba(30, 41, 59, 0.95);
+      border: 1px solid rgba(148, 163, 184, 0.2);
+    }
+    .fade-in { animation: fadeIn 0.6s ease-out forwards; opacity: 0; }
+    @keyframes fadeIn {
+      from { opacity: 0; transform: translateY(20px); }
+      to { opacity: 1; transform: translateY(0); }
+    }
+    .theme-toggle:hover { transform: rotate(15deg) scale(1.1); }
+    .input-field:focus { transform: scale(1.01); box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.3); }
     @media print {
       body * { visibility: hidden; }
       #printableReport, #printableReport * { visibility: visible; }
       #printableReport { position: absolute; left: 0; top: 0; width: 100%; }
       .no-print { display: none !important; }
     }
-    .glass-card {
-      background: rgba(255, 255, 255, 0.95);
-      backdrop-filter: blur(10px);
-    }
-    .dark .glass-card {
-      background: rgba(30, 41, 59, 0.95);
-    }
   </style>
 </head>
 
-<body class="min-h-screen bg-gradient-to-br from-blue-50 via-blue-100 to-blue-200 dark:from-slate-900 dark:via-slate-800 dark:to-slate-900 flex flex-col font-sans transition-colors duration-300">
-  {% include 'navbar.html' %}
+<body class="min-h-screen bg-gray-50 dark:bg-slate-950 transition-colors duration-300">
 
-  <main class="flex-grow flex items-center justify-center p-8">
-    <section class="bg-white bg-opacity-90 backdrop-blur-md rounded-3xl shadow-2xl max-w-lg w-full p-12 space-y-10">
-      <header>
-        <h1 class="text-4xl font-extrabold text-blue-900 flex items-center gap-4 mb-12 select-none">
-          <svg xmlns="http://www.w3.org/2000/svg" class="h-11 w-11 text-blue-700" fill="none" viewBox="0 0 24 24"
-            stroke="currentColor" stroke-width="2" aria-hidden="true" focusable="false">
-            <path stroke-linecap="round" stroke-linejoin="round"
-              d="M9 12h6m-3-3v6m-6 4h12a2 2 0 002-2V7a2 2 0 00-2-2H6a2 2 0 00-2 2v9a2 2 0 002 2z" />
-          </svg>
-          {{ _('Diabetes Prediction') }}
-        </h1>
-      </header>
-
-      <form action="/predict" method="post" class="space-y-8">
-        <div>
-          <label for="Pregnancies" class="block text-blue-800 font-semibold mb-2">Pregnancies</label>
-          <input type="number" id="Pregnancies" name="Pregnancies" placeholder="e.g., 2" required min="0"
-            class="w-full rounded-xl border border-blue-300 focus:border-blue-600 focus:ring-4 focus:ring-blue-300 px-5 py-3 text-blue-900 placeholder-blue-400 transition-shadow duration-300" />
+  <!-- Navbar -->
+  <nav class="bg-gradient-to-r from-blue-600 to-indigo-700 dark:from-slate-800 dark:to-slate-900 text-white shadow-lg sticky top-0 z-50">
+    <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+      <div class="flex justify-between items-center h-16">
+        <a href="/" class="flex items-center gap-2">
+          <span class="text-2xl">⚕️</span>
+          <span class="text-xl font-bold">Diabetes<span class="text-cyan-300">Care</span></span>
+        </a>
+        <div class="hidden md:flex items-center gap-6">
+          <a href="/" class="hover:text-cyan-300 transition font-medium">{{ _('Home') }}</a>
+          <a href="/index" class="text-cyan-300 font-bold">{{ _('Prediction') }}</a>
+          <a href="/life" class="hover:text-cyan-300 transition font-medium">{{ _('Lifestyle') }}</a>
+          <a href="/chatbot" class="hover:text-cyan-300 transition font-medium">{{ _('Chatbot') }}</a>
+          <a href="/explore" class="hover:text-cyan-300 transition font-medium">{{ _('Explore') }}</a>
+          <a href="/forum" class="hover:text-cyan-300 transition font-medium">{{ _('Forum') }}</a>
         </div>
-
-        <div>
-          <label for="Glucose" class="block text-blue-800 font-semibold mb-2">Glucose Level</label>
-          <input type="number" id="Glucose" name="Glucose" placeholder="e.g., 130" required min="0"
-            class="w-full rounded-xl border border-blue-300 focus:border-blue-600 focus:ring-4 focus:ring-blue-300 px-5 py-3 text-blue-900 placeholder-blue-400 transition-shadow duration-300" />
+        <div class="flex items-center gap-3">
+          <button onclick="toggleTheme()" class="theme-toggle p-2 rounded-lg hover:bg-white/10 transition" aria-label="Toggle dark mode">
+            <svg id="theme-icon-sun" class="w-5 h-5 hidden" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z"/>
+            </svg>
+            <svg id="theme-icon-moon" class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"/>
+            </svg>
+          </button>
         </div>
-
-        <div>
-          <label for="BloodPressure" class="block text-blue-800 font-semibold mb-2">Blood Pressure</label>
-          <input type="number" id="BloodPressure" name="BloodPressure" placeholder="e.g., 70" required min="0"
-            class="w-full rounded-xl border border-blue-300 focus:border-blue-600 focus:ring-4 focus:ring-blue-300 px-5 py-3 text-blue-900 placeholder-blue-400 transition-shadow duration-300" />
-        </div>
-
-        <div>
-          <label for="SkinThickness" class="block text-blue-800 font-semibold mb-2">Skin Thickness</label>
-          <input type="number" id="SkinThickness" name="SkinThickness" placeholder="e.g., 32" required min="0"
-            class="w-full rounded-xl border border-blue-300 focus:border-blue-600 focus:ring-4 focus:ring-blue-300 px-5 py-3 text-blue-900 placeholder-blue-400 transition-shadow duration-300" />
-        </div>
-
-        <div>
-          <label for="Insulin" class="block text-blue-800 font-semibold mb-2">Insulin Level</label>
-          <input type="number" id="Insulin" name="Insulin" placeholder="e.g., 85" required min="0"
-            class="w-full rounded-xl border border-blue-300 focus:border-blue-600 focus:ring-4 focus:ring-blue-300 px-5 py-3 text-blue-900 placeholder-blue-400 transition-shadow duration-300" />
-        </div>
-
-        <div>
-          <label for="BMI" class="block text-blue-800 font-semibold mb-2">BMI</label>
-          <input type="number" step="0.1" id="BMI" name="BMI" placeholder="e.g., 28.5" required min="0"
-            class="w-full rounded-xl border border-blue-300 focus:border-blue-600 focus:ring-4 focus:ring-blue-300 px-5 py-3 text-blue-900 placeholder-blue-400 transition-shadow duration-300" />
-        </div>
-
-        <div>
-          <label for="DiabetesPedigreeFunction" class="block text-blue-800 font-semibold mb-2">Diabetes Pedigree
-            Function</label>
-          <input type="number" step="0.01" id="DiabetesPedigreeFunction" name="DiabetesPedigreeFunction"
-            placeholder="e.g., 0.45" required min="0"
-            class="w-full rounded-xl border border-blue-300 focus:border-blue-600 focus:ring-4 focus:ring-blue-300 px-5 py-3 text-blue-900 placeholder-blue-400 transition-shadow duration-300" />
-        </div>
-
-        <div>
-          <label for="Age" class="block text-blue-800 font-semibold mb-2">Age</label>
-          <input type="number" id="Age" name="Age" placeholder="e.g., 35" required min="0"
-            class="w-full rounded-xl border border-blue-300 focus:border-blue-600 focus:ring-4 focus:ring-blue-300 px-5 py-3 text-blue-900 placeholder-blue-400 transition-shadow duration-300" />
-        </div>
-
-        <button type="submit"
-          class="w-full bg-blue-700 hover:bg-blue-800 text-white font-extrabold rounded-2xl py-4 shadow-lg transition-transform duration-300 hover:scale-105 flex justify-center items-center gap-3 select-none">
-          <svg xmlns="http://www.w3.org/2000/svg" class="h-7 w-7" fill="none" viewBox="0 0 24 24" stroke="currentColor"
-            stroke-width="2" aria-hidden="true" focusable="false">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M12 20h9" />
-            <path stroke-linecap="round" stroke-linejoin="round" d="M12 4v16m0 0L8 12m4 8l4-8" />
-          </svg>
-          {{ _('Predict') }}
-        </button>
-      </form>
-
-      {% if prediction_text %}
-      <div id="predictionResult"
-        class="mt-10 mx-auto max-w-xl bg-blue-100 bg-opacity-70 border border-blue-400 rounded-3xl p-8 text-blue-900 font-semibold text-center text-xl shadow-lg backdrop-blur-sm"
-        role="alert">
-        {{ prediction_text }}
       </div>
+    </div>
+  </nav>
+
+  <!-- Hero Section -->
+  <section class="bg-gradient-to-br from-blue-600 via-indigo-600 to-cyan-500 dark:from-slate-800 dark:via-slate-900 dark:to-slate-800 py-12">
+    <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
+      <div class="fade-in">
+        <div class="inline-flex items-center justify-center w-16 h-16 bg-white/20 rounded-2xl mb-4">
+          <svg class="w-8 h-8 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4"/>
+          </svg>
+        </div>
+        <h1 class="text-3xl md:text-4xl font-bold text-white mb-3">{{ _('Diabetes Prediction') }}</h1>
+        <p class="text-blue-100 text-lg max-w-2xl mx-auto">{{ _('Enter your health metrics to get an AI-powered diabetes risk assessment') }}</p>
+      </div>
+    </div>
+  </section>
+
+  <!-- Main Content -->
+  <main class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-10">
+    <div class="grid lg:grid-cols-3 gap-8">
       
-      <!-- Print and Download Buttons -->
-      <div class="mt-4 flex justify-center gap-4 no-print">
-        <button onclick="printReport()" 
-          class="flex items-center gap-2 bg-blue-600 hover:bg-blue-700 text-white font-semibold py-3 px-6 rounded-xl shadow-md transition-transform duration-300 hover:scale-105">
-          <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M17 17h2a2 2 0 002-2v-4a2 2 0 00-2-2H5a2 2 0 00-2 2v4a2 2 0 002 2h2m2 4h6a2 2 0 002-2v-4a2 2 0 00-2-2H9a2 2 0 00-2 2v4a2 2 0 002 2zm8-12V5a2 2 0 00-2-2H9a2 2 0 00-2 2v4h10z" />
-          </svg>
-          {{ _('Print Report') }}
-        </button>
-        <button onclick="downloadPDF()" 
-          class="flex items-center gap-2 bg-green-600 hover:bg-green-700 text-white font-semibold py-3 px-6 rounded-xl shadow-md transition-transform duration-300 hover:scale-105">
-          <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
-          </svg>
-          {{ _('Download PDF') }}
-        </button>
-      </div>
-
-      <!-- Hidden Printable Report -->
-      <div id="printableReport" class="hidden print:block absolute left-0 top-0 w-full bg-white p-8">
-        <div class="max-w-2xl mx-auto">
-          <h1 class="text-3xl font-bold text-blue-900 text-center mb-6">DIABETES PREDICTION REPORT</h1>
-          <p class="text-gray-600 text-center mb-8" id="reportDate"></p>
-          
-          <div class="bg-blue-50 border-2 border-blue-400 rounded-xl p-6 mb-6">
-            <h2 class="text-xl font-bold text-blue-800 mb-2">RESULT</h2>
-            <p class="text-2xl font-bold" id="reportResult">{{ prediction_text }}</p>
+      <!-- Form Section -->
+      <div class="lg:col-span-2">
+        <div class="glass-card rounded-2xl shadow-xl overflow-hidden fade-in">
+          <div class="bg-gradient-to-r from-blue-600 to-indigo-600 dark:from-indigo-700 dark:to-purple-800 px-6 py-4">
+            <div class="flex items-center gap-3">
+              <div class="w-10 h-10 bg-white/20 rounded-xl flex items-center justify-center">
+                <svg class="w-5 h-5 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/>
+                </svg>
+              </div>
+              <div>
+                <h2 class="text-xl font-bold text-white">{{ _('Health Metrics') }}</h2>
+                <p class="text-blue-100 text-sm">{{ _('Enter your values for prediction') }}</p>
+              </div>
+            </div>
           </div>
           
-          <div class="bg-gray-50 border border-gray-300 rounded-xl p-6 mb-6">
-            <h2 class="text-xl font-bold text-gray-800 mb-4">INPUT VALUES</h2>
-            <ul class="space-y-2 text-gray-700" id="reportInputValues"></ul>
+          <form action="/predict" method="post" class="p-6 bg-white dark:bg-slate-900">
+            <div class="grid md:grid-cols-2 gap-5">
+              <!-- Pregnancies -->
+              <div>
+                <label for="Pregnancies" class="block text-sm font-semibold text-gray-700 dark:text-gray-300 mb-2">{{ _('Pregnancies') }}</label>
+                <input type="number" id="Pregnancies" name="Pregnancies" placeholder="e.g., 2" required min="0"
+                  class="input-field w-full px-4 py-3 bg-gray-50 dark:bg-slate-800 border-2 border-gray-200 dark:border-slate-700 rounded-xl focus:border-blue-500 dark:focus:border-blue-400 outline-none transition text-gray-800 dark:text-white" />
+              </div>
+              
+              <!-- Glucose -->
+              <div>
+                <label for="Glucose" class="block text-sm font-semibold text-gray-700 dark:text-gray-300 mb-2">{{ _('Glucose Level') }} <span class="text-xs text-gray-400">(mg/dL)</span></label>
+                <input type="number" id="Glucose" name="Glucose" placeholder="e.g., 130" required min="0"
+                  class="input-field w-full px-4 py-3 bg-gray-50 dark:bg-slate-800 border-2 border-gray-200 dark:border-slate-700 rounded-xl focus:border-blue-500 dark:focus:border-blue-400 outline-none transition text-gray-800 dark:text-white" />
+              </div>
+              
+              <!-- Blood Pressure -->
+              <div>
+                <label for="BloodPressure" class="block text-sm font-semibold text-gray-700 dark:text-gray-300 mb-2">{{ _('Blood Pressure') }} <span class="text-xs text-gray-400">(mm Hg)</span></label>
+                <input type="number" id="BloodPressure" name="BloodPressure" placeholder="e.g., 70" required min="0"
+                  class="input-field w-full px-4 py-3 bg-gray-50 dark:bg-slate-800 border-2 border-gray-200 dark:border-slate-700 rounded-xl focus:border-blue-500 dark:focus:border-blue-400 outline-none transition text-gray-800 dark:text-white" />
+              </div>
+              
+              <!-- Skin Thickness -->
+              <div>
+                <label for="SkinThickness" class="block text-sm font-semibold text-gray-700 dark:text-gray-300 mb-2">{{ _('Skin Thickness') }} <span class="text-xs text-gray-400">(mm)</span></label>
+                <input type="number" id="SkinThickness" name="SkinThickness" placeholder="e.g., 32" required min="0"
+                  class="input-field w-full px-4 py-3 bg-gray-50 dark:bg-slate-800 border-2 border-gray-200 dark:border-slate-700 rounded-xl focus:border-blue-500 dark:focus:border-blue-400 outline-none transition text-gray-800 dark:text-white" />
+              </div>
+              
+              <!-- Insulin -->
+              <div>
+                <label for="Insulin" class="block text-sm font-semibold text-gray-700 dark:text-gray-300 mb-2">{{ _('Insulin Level') }} <span class="text-xs text-gray-400">(μU/mL)</span></label>
+                <input type="number" id="Insulin" name="Insulin" placeholder="e.g., 85" required min="0"
+                  class="input-field w-full px-4 py-3 bg-gray-50 dark:bg-slate-800 border-2 border-gray-200 dark:border-slate-700 rounded-xl focus:border-blue-500 dark:focus:border-blue-400 outline-none transition text-gray-800 dark:text-white" />
+              </div>
+              
+              <!-- BMI -->
+              <div>
+                <label for="BMI" class="block text-sm font-semibold text-gray-700 dark:text-gray-300 mb-2">{{ _('BMI') }} <span class="text-xs text-gray-400">(kg/m²)</span></label>
+                <input type="number" step="0.1" id="BMI" name="BMI" placeholder="e.g., 28.5" required min="0"
+                  class="input-field w-full px-4 py-3 bg-gray-50 dark:bg-slate-800 border-2 border-gray-200 dark:border-slate-700 rounded-xl focus:border-blue-500 dark:focus:border-blue-400 outline-none transition text-gray-800 dark:text-white" />
+              </div>
+              
+              <!-- Diabetes Pedigree Function -->
+              <div>
+                <label for="DiabetesPedigreeFunction" class="block text-sm font-semibold text-gray-700 dark:text-gray-300 mb-2">{{ _('Diabetes Pedigree') }} <span class="text-xs text-gray-400">(0-2.5)</span></label>
+                <input type="number" step="0.01" id="DiabetesPedigreeFunction" name="DiabetesPedigreeFunction" placeholder="e.g., 0.45" required min="0"
+                  class="input-field w-full px-4 py-3 bg-gray-50 dark:bg-slate-800 border-2 border-gray-200 dark:border-slate-700 rounded-xl focus:border-blue-500 dark:focus:border-blue-400 outline-none transition text-gray-800 dark:text-white" />
+              </div>
+              
+              <!-- Age -->
+              <div>
+                <label for="Age" class="block text-sm font-semibold text-gray-700 dark:text-gray-300 mb-2">{{ _('Age') }} <span class="text-xs text-gray-400">({{ _('years') }})</span></label>
+                <input type="number" id="Age" name="Age" placeholder="e.g., 35" required min="0"
+                  class="input-field w-full px-4 py-3 bg-gray-50 dark:bg-slate-800 border-2 border-gray-200 dark:border-slate-700 rounded-xl focus:border-blue-500 dark:focus:border-blue-400 outline-none transition text-gray-800 dark:text-white" />
+              </div>
+            </div>
+            
+            <!-- Submit Button -->
+            <button type="submit"
+              class="w-full mt-6 py-4 bg-gradient-to-r from-blue-600 to-indigo-600 hover:from-blue-700 hover:to-indigo-700 text-white font-bold rounded-xl shadow-lg hover:shadow-xl transition-all duration-300 flex items-center justify-center gap-3">
+              <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4"/>
+              </svg>
+              {{ _('Get Prediction') }}
+            </button>
+          </form>
+        </div>
+        
+        <!-- Prediction Result -->
+        {% if prediction_text %}
+        <div id="predictionResult" class="mt-6 glass-card rounded-2xl shadow-xl overflow-hidden fade-in">
+          <div class="bg-gradient-to-r from-cyan-600 to-blue-600 dark:from-cyan-700 dark:to-blue-800 px-6 py-4">
+            <h3 class="text-xl font-bold text-white flex items-center gap-2">
+              <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"/>
+              </svg>
+              {{ _('Prediction Result') }}
+            </h3>
           </div>
-          
-          <div class="bg-yellow-50 border border-yellow-400 rounded-xl p-4 mt-6">
-            <p class="text-sm text-yellow-800">
-              <strong>DISCLAIMER:</strong> This prediction is for informational purposes only and should not be considered medical advice. Please consult a healthcare professional for proper diagnosis.
-            </p>
+          <div class="p-6 bg-white dark:bg-slate-900">
+            <p class="text-xl font-semibold text-center text-gray-800 dark:text-white mb-4">{{ prediction_text }}</p>
+            
+            <!-- Action Buttons -->
+            <div class="flex flex-wrap justify-center gap-3 no-print">
+              <button onclick="printReport()" class="flex items-center gap-2 px-5 py-2.5 bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-400 font-medium rounded-xl hover:bg-blue-200 dark:hover:bg-blue-900/50 transition">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 17h2a2 2 0 002-2v-4a2 2 0 00-2-2H5a2 2 0 00-2 2v4a2 2 0 002 2h2m2 4h6a2 2 0 002-2v-4a2 2 0 00-2-2H9a2 2 0 00-2 2v4a2 2 0 002 2zm8-12V5a2 2 0 00-2-2H9a2 2 0 00-2 2v4h10z"/>
+                </svg>
+                {{ _('Print') }}
+              </button>
+              <button onclick="downloadPDF()" class="flex items-center gap-2 px-5 py-2.5 bg-indigo-100 dark:bg-indigo-900/30 text-indigo-700 dark:text-indigo-400 font-medium rounded-xl hover:bg-indigo-200 dark:hover:bg-indigo-900/50 transition">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/>
+                </svg>
+                {{ _('Download PDF') }}
+              </button>
+            </div>
           </div>
         </div>
+        {% endif %}
       </div>
-      {% endif %}
 
-        <a href="/explore"
-        class="mt-8 block mx-auto max-w-xl text-center bg-blue-600 hover:bg-blue-700 text-white font-semibold rounded-2xl py-4 shadow-md transition-transform duration-300 hover:scale-105 select-none">
-        📊 {{ _('Explore Dataset') }}
-      </a>
-
-      <a href="/life"
-        class="mt-8 block mx-auto max-w-xl text-center bg-blue-600 hover:bg-blue-700 text-white font-semibold rounded-2xl py-4 shadow-md transition-transform duration-300 hover:scale-105 select-none">
-        📊 {{ _('CHECK YOUR LIFESTYLE') }}
-      </a>
-    </section>
+      <!-- Sidebar -->
+      <div class="space-y-6">
+        <!-- Info Card -->
+        <div class="glass-card rounded-2xl p-5 shadow-lg fade-in">
+          <div class="w-10 h-10 bg-blue-100 dark:bg-blue-900/50 rounded-xl flex items-center justify-center mb-3">
+            <svg class="w-5 h-5 text-blue-600 dark:text-blue-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
+            </svg>
+          </div>
+          <h3 class="font-bold text-gray-800 dark:text-white mb-2">{{ _('About This Tool') }}</h3>
+          <p class="text-sm text-gray-600 dark:text-gray-400">{{ _('This AI model predicts diabetes risk based on the Pima Indians Diabetes Dataset. Results are for informational purposes only.') }}</p>
+        </div>
+        
+        <!-- Tips Card -->
+        <div class="glass-card rounded-2xl p-5 shadow-lg fade-in">
+          <div class="w-10 h-10 bg-indigo-100 dark:bg-indigo-900/50 rounded-xl flex items-center justify-center mb-3">
+            <svg class="w-5 h-5 text-indigo-600 dark:text-indigo-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z"/>
+            </svg>
+          </div>
+          <h3 class="font-bold text-gray-800 dark:text-white mb-2">{{ _('Input Tips') }}</h3>
+          <ul class="text-sm text-gray-600 dark:text-gray-400 space-y-1">
+            <li>• {{ _('Glucose: Fasting blood sugar') }}</li>
+            <li>• {{ _('BMI: Weight(kg) / Height(m)²') }}</li>
+            <li>• {{ _('Pedigree: Family history score') }}</li>
+          </ul>
+        </div>
+        
+        <!-- Quick Links -->
+        <div class="glass-card rounded-2xl p-5 shadow-lg fade-in">
+          <h3 class="font-bold text-gray-800 dark:text-white mb-3">{{ _('Quick Links') }}</h3>
+          <div class="space-y-2">
+            <a href="/life" class="flex items-center gap-2 p-3 rounded-xl bg-cyan-50 dark:bg-slate-800 hover:bg-cyan-100 dark:hover:bg-slate-700 transition text-cyan-700 dark:text-cyan-400 text-sm font-medium">
+              <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z"/>
+              </svg>
+              {{ _('Lifestyle Check') }}
+            </a>
+            <a href="/explore" class="flex items-center gap-2 p-3 rounded-xl bg-indigo-50 dark:bg-slate-800 hover:bg-indigo-100 dark:hover:bg-slate-700 transition text-indigo-700 dark:text-indigo-400 text-sm font-medium">
+              <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 12l3-3 3 3 4-4M8 21l4-4 4 4M3 4h18M4 4h16v12a1 1 0 01-1 1H5a1 1 0 01-1-1V4z"/>
+              </svg>
+              {{ _('Explore Data') }}
+            </a>
+            <a href="/chatbot" class="flex items-center gap-2 p-3 rounded-xl bg-blue-50 dark:bg-slate-800 hover:bg-blue-100 dark:hover:bg-slate-700 transition text-blue-700 dark:text-blue-400 text-sm font-medium">
+              <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z"/>
+              </svg>
+              {{ _('AI Chatbot') }}
+            </a>
+          </div>
+        </div>
+        
+        <!-- Disclaimer -->
+        <div class="bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-xl p-4">
+          <p class="text-xs text-amber-800 dark:text-amber-400">
+            <strong>{{ _('Disclaimer:') }}</strong> {{ _('This tool is for educational purposes only. Always consult a healthcare professional for medical advice.') }}
+          </p>
+        </div>
+      </div>
+    </div>
   </main>
 
-  <!-- Chatbot Floating Button -->
+  <!-- Hidden Printable Report -->
+  <div id="printableReport" class="hidden print:block absolute left-0 top-0 w-full bg-white p-8">
+    <div class="max-w-2xl mx-auto">
+      <h1 class="text-3xl font-bold text-blue-900 text-center mb-6">DIABETES PREDICTION REPORT</h1>
+      <p class="text-gray-600 text-center mb-8" id="reportDate"></p>
+      <div class="bg-blue-50 border-2 border-blue-400 rounded-xl p-6 mb-6">
+        <h2 class="text-xl font-bold text-blue-800 mb-2">RESULT</h2>
+        <p class="text-2xl font-bold" id="reportResult">{% if prediction_text %}{{ prediction_text }}{% endif %}</p>
+      </div>
+      <div class="bg-gray-50 border border-gray-300 rounded-xl p-6 mb-6">
+        <h2 class="text-xl font-bold text-gray-800 mb-4">INPUT VALUES</h2>
+        <ul class="space-y-2 text-gray-700" id="reportInputValues"></ul>
+      </div>
+      <div class="bg-yellow-50 border border-yellow-400 rounded-xl p-4 mt-6">
+        <p class="text-sm text-yellow-800">
+          <strong>DISCLAIMER:</strong> This prediction is for informational purposes only and should not be considered medical advice. Please consult a healthcare professional for proper diagnosis.
+        </p>
+      </div>
+    </div>
+  </div>
+
+  <!-- Chatbot FAB -->
   <a href="/chatbot" aria-label="Chatbot" title="Chatbot"
-    class="fixed bottom-8 right-8 bg-blue-700 hover:bg-blue-800 text-white rounded-full w-16 h-16 flex items-center justify-center shadow-lg transition-transform duration-300 hover:scale-110 z-50 select-none">
-    <!-- Robot icon SVG -->
-    <svg xmlns="http://www.w3.org/2000/svg" class="h-9 w-9" fill="none" viewBox="0 0 24 24" stroke="currentColor"
-      stroke-width="2" aria-hidden="true" focusable="false">
-      <rect x="7" y="7" width="10" height="10" rx="2" ry="2" />
-      <path stroke-linecap="round" stroke-linejoin="round" d="M7 17h10M9 10h.01M15 10h.01" />
+    class="fixed bottom-6 right-6 bg-gradient-to-r from-blue-600 to-indigo-600 hover:from-blue-700 hover:to-indigo-700 text-white rounded-full w-14 h-14 flex items-center justify-center shadow-lg transition-all duration-300 hover:scale-110 z-50">
+    <svg class="w-7 h-7" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z"/>
     </svg>
   </a>
 
-  <script>
-    document.getElementById('lang-btn').addEventListener('click', function(e) {
-      e.stopPropagation();
-      document.getElementById('lang-dropdown').classList.toggle('show');
-    });
-    document.addEventListener('click', function() {
-      document.getElementById('lang-dropdown').classList.remove('show');
-    });
-    function setLanguage(langCode) {
-      fetch('/api/set-language', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ language: langCode })
-      })
-      .then(response => response.json())
-      .then(data => { if (data.success) window.location.reload(); })
-      .catch(err => console.error('Language switch failed:', err));
-    }
+  <!-- Footer -->
+  <footer class="bg-gradient-to-r from-slate-800 to-slate-900 text-white py-8 mt-auto">
+    <div class="max-w-7xl mx-auto px-4 text-center">
+      <p class="text-gray-400">© {{ current_year }} {{ _('Diabetes Care with AI') }}. {{ _('All rights reserved.') }}</p>
+    </div>
+  </footer>
 
-    // Print and PDF Download Functions
+  <script>
+    // Dark mode
+    function toggleTheme() {
+      var isDark = document.documentElement.classList.toggle('dark');
+      localStorage.setItem('theme', isDark ? 'dark' : 'light');
+      updateThemeIcons();
+    }
+    function updateThemeIcons() {
+      var isDark = document.documentElement.classList.contains('dark');
+      document.getElementById('theme-icon-sun').classList.toggle('hidden', !isDark);
+      document.getElementById('theme-icon-moon').classList.toggle('hidden', isDark);
+    }
+    document.addEventListener('DOMContentLoaded', updateThemeIcons);
+
+    // Print and PDF functions
     function getInputValues() {
       return {
         'Pregnancies': document.getElementById('Pregnancies')?.value || 'N/A',
@@ -224,62 +338,53 @@
         'Skin Thickness': document.getElementById('SkinThickness')?.value || 'N/A',
         'Insulin Level': document.getElementById('Insulin')?.value || 'N/A',
         'BMI': document.getElementById('BMI')?.value || 'N/A',
-        'Diabetes Pedigree Function': document.getElementById('DiabetesPedigreeFunction')?.value || 'N/A',
+        'Diabetes Pedigree': document.getElementById('DiabetesPedigreeFunction')?.value || 'N/A',
         'Age': document.getElementById('Age')?.value || 'N/A'
       };
     }
-
     function formatDate() {
-      return new Date().toLocaleString('en-US', {
-        year: 'numeric', month: 'long', day: 'numeric',
-        hour: '2-digit', minute: '2-digit'
-      });
+      return new Date().toLocaleString('en-US', { year: 'numeric', month: 'long', day: 'numeric', hour: '2-digit', minute: '2-digit' });
     }
-
     function prepareReport() {
-      const reportDate = document.getElementById('reportDate');
-      const reportInputValues = document.getElementById('reportInputValues');
-      
+      var reportDate = document.getElementById('reportDate');
+      var reportInputValues = document.getElementById('reportInputValues');
       if (reportDate) reportDate.textContent = 'Date: ' + formatDate();
-      
       if (reportInputValues) {
-        const values = getInputValues();
-        reportInputValues.innerHTML = Object.entries(values)
-          .map(([key, val]) => '<li><strong>' + key + ':</strong> ' + val + '</li>')
-          .join('');
+        var values = getInputValues();
+        reportInputValues.innerHTML = Object.entries(values).map(function(entry) {
+          return '<li><strong>' + entry[0] + ':</strong> ' + entry[1] + '</li>';
+        }).join('');
       }
     }
-
     function printReport() {
       prepareReport();
-      const printableReport = document.getElementById('printableReport');
+      var printableReport = document.getElementById('printableReport');
       if (printableReport) {
         printableReport.classList.remove('hidden');
         window.print();
-        setTimeout(() => printableReport.classList.add('hidden'), 100);
+        setTimeout(function() { printableReport.classList.add('hidden'); }, 100);
       }
     }
-
     function downloadPDF() {
       prepareReport();
-      const printableReport = document.getElementById('printableReport');
+      var printableReport = document.getElementById('printableReport');
       if (printableReport && typeof html2pdf !== 'undefined') {
         printableReport.classList.remove('hidden');
-        const opt = {
+        var opt = {
           margin: 10,
           filename: 'diabetes-prediction-report-' + Date.now() + '.pdf',
           image: { type: 'jpeg', quality: 0.98 },
           html2canvas: { scale: 2 },
           jsPDF: { unit: 'mm', format: 'a4', orientation: 'portrait' }
         };
-        html2pdf().set(opt).from(printableReport).save().then(() => {
+        html2pdf().set(opt).from(printableReport).save().then(function() {
           printableReport.classList.add('hidden');
         });
       } else {
-        alert('PDF generation is not available. Please try the Print option instead.');
+        alert('PDF generation is not available.');
       }
     }
   </script>
 </body>
-
 </html>
+""


### PR DESCRIPTION
## Summary
Redesigns the Diabetes Prediction page (`/index`) with a modern white/blue theme matching the home page aesthetic.

## Changes Made

### Visual Improvements
- Blue/indigo gradient hero section matching home page
- Glass-card form container with gradient header
- Modern input fields with unit labels (mg/dL, mm Hg, etc.)
- Fade-in animations for smooth page load
- Floating chatbot button with gradient

### Layout Changes
- Two-column layout: form on left, info sidebar on right
- Responsive design - stacks on mobile
- Better spacing and typography hierarchy
- 2x4 grid for form inputs

### Sidebar Features
- "About This Tool" info card
- "Input Tips" card explaining medical terms
- Quick Links to Lifestyle, Explore, Chatbot
- Medical disclaimer in amber warning box

### Result Display
- Enhanced result card with gradient header
- Print and Download PDF buttons
- Clean, professional appearance

### Dark Mode Support
- Full dark mode with slate backgrounds
- Proper contrast for all elements
- Theme toggle in navbar
- Persists preference in localStorage

### Bug Fix
- Fixed undefined `client` variable in `/generate` route

## Screenshots
The new design features:
- White/blue gradient theme matching home page
- Two-column layout with sidebar
- Glass-card form with gradient header
- Modern input fields with units
- Info cards and quick links

## Testing
- [x] Light mode displays correctly
- [x] Dark mode displays correctly
- [x] Form submission works
- [x] Prediction result displays
- [x] Print/PDF buttons work
- [x] Responsive on mobile devices

## Screenshot
<img width="1919" height="911" alt="Screenshot 2026-01-10 031638" src="https://github.com/user-attachments/assets/f109a53d-98f7-47f3-85bd-c468d7a39d82" />


Closes #128
