### PR TITLE
Security: Restrict GITHUB_TOKEN permissions in CI/CD workflow

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -7,6 +7,9 @@ on:
     branches: [main, master]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Lint Check


### PR DESCRIPTION
## 📌 Description
Resolves the CodeQL security alert `actions/missing-workflow-permissions`. 

This PR adds an explicit `permissions: contents: read` block to the CI/CD workflow (`.github/workflows/ci-cd.yml`). This ensures the `GITHUB_TOKEN` adheres to the **Principle of Least Privilege**, granting only read-only access to the repository and preventing potential token abuse.

---

## 🔧 Type of Change
Please mark the relevant option(s):

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📝 Documentation update
- [x] ♻️ Refactor / Code cleanup
- [ ] 🎨 UI / Styling change
- [x] 🚀 Other (please describe): Security Hardening

---

## 🧪 How Has This Been Tested?
Describe the tests you ran to verify your changes.

- [ ] Manual testing
- [x] Automated tests
- [ ] Not tested (please explain why)

*Verified that the workflow syntax is valid and that the permissions block is correctly placed at the top level of the YAML file.*

---

## 📸 Screenshots (if applicable)
N/A (Code configuration change only)

---

## ✅ Checklist
Please confirm the following:

- [x] My code follows the project’s coding style
- [x] I have tested my changes
- [x] I have updated documentation where necessary
- [x] This PR does not introduce breaking changes

---

## 📝 Additional Notes
This change is zero-risk to the application logic but significantly improves the security posture of the CI pipeline.