### PR TITLE
Fix: improve placeholder color in dark mode

### DIFF
--- a/templates/life.html
+++ b/templates/life.html
@@ -210,13 +210,15 @@
               placeholder="{{ _('Enter your height in cm') }}"
               inputmode="decimal"
               autocomplete="height"
-              class="w-full border border-gray-300 rounded-xl px-4 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500 shadow-sm"
+              class="w-full border border-gray-300 dark:border-slate-600 dark:bg-slate-700 dark:text-white rounded-xl px-4 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500 shadow-sm"
               required
             />
           </div>
 
           <div>
-            <label for="bmi" class="block font-semibold mb-1 text-gray-700"
+            <label 
+              for="bmi" 
+              class="block font-semibold mb-1 text-gray-700 dark:text-gray-300"
               >{{ _('BMI (Body Mass Index)') }}</label
             >
             <input
@@ -229,7 +231,7 @@
               placeholder="{{ _('Enter your BMI') }}"
               inputmode="decimal"
               aria-describedby="bmi-hint"
-              class="w-full border border-gray-300 rounded-xl px-4 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500 shadow-sm"
+              class="w-full border border-gray-300 dark:border-slate-600 dark:bg-slate-700 dark:text-white rounded-xl px-4 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500 shadow-sm"
               required
             />
             <p id="bmi-hint" class="text-xs text-gray-500 mt-1">
@@ -238,13 +240,15 @@
           </div>
 
           <div>
-            <label for="activity" class="block font-semibold mb-1 text-gray-700"
+            <label 
+              for="activity" 
+              class="block font-semibold mb-1 text-gray-700 dark:text-gray-300"
               >{{ _('Physical Activity Level') }}</label
             >
             <select
               id="activity"
               name="activity"
-              class="w-full border border-gray-300 rounded-xl px-4 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500 shadow-sm"
+              class="w-full border border-gray-300 dark:border-slate-600 dark:bg-slate-700 dark:text-white rounded-xl px-4 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500 shadow-sm"
               required
             >
               <option value="" disabled selected>


### PR DESCRIPTION
## 📌 What does this PR do?
This PR improves the placeholder text color styling in dark mode on the Lifestyle page form inputs.
Previously, some inputs (Height, BMI, Activity) had placeholder colors that did not match the dark theme styling and appeared inconsistent compared to other fields.

This update ensures consistent and readable placeholder color behavior across all input fields in dark mode.

---

## 🛠️ Changes Made
- Added proper dark-mode placeholder text color.
- Ensured visual consistency between Age, Weight, Height, BMI, and Activity fields.
- No backend logic was modified.

---

## 📸 Screenshots
Before: 
placeholder colors  did not match the dark theme styling 
<img width="1858" height="881" alt="image" src="https://github.com/user-attachments/assets/947b37e4-a659-4622-9b75-44abb32ac5c3" />

After: 
consistent placeholder colors across all input fields in dark mode
<img width="1736" height="811" alt="image" src="https://github.com/user-attachments/assets/ce5b5118-1e50-4167-a277-72d4a7f1d44e" />

---

#### Notes
This is a frontend-only UI improvement.
Backend could not be run locally due to Python dependency incompatibility. 
CSS fix verified via static preview.